### PR TITLE
Add dev sign-in button for one-click authentication

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
+  allow_unauthenticated_access only: %i[ new create dev_signin ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new
@@ -17,5 +17,19 @@ class SessionsController < ApplicationController
   def destroy
     terminate_session
     redirect_to new_session_path
+  end
+
+  def dev_signin
+    if Rails.env.development? || Rails.env.test?
+      user = User.find_by(email_address: "test@example.com")
+      if user
+        start_new_session_for user
+        redirect_to after_authentication_url, notice: "Signed in as test@example.com (dev mode)"
+      else
+        redirect_to new_session_path, alert: "Dev user not found. Run 'rails db:seed' to create it."
+      end
+    else
+      redirect_to new_session_path
+    end
   end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,3 +9,8 @@
 <br>
 
 <%= link_to "Forgot password?", new_password_path %>
+
+<% if Rails.env.development? %>
+  <hr style="margin: 20px 0;">
+  <%= button_to "Dev Sign In", dev_signin_session_path, method: :post, style: "background-color: #4CAF50; color: white; padding: 10px 20px; border: none; cursor: pointer;" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  resource :session
+  resource :session do
+    collection do
+      post :dev_signin if Rails.env.development? || Rails.env.test?
+    end
+  end
   resources :passwords, param: :token
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -12,5 +16,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root to: redirect("/session/new")
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "dev signin signs in the seeded user in development" do
+    User.create!(email_address: "test@example.com", password: "password")
+
+    post dev_signin_session_url
+
+    assert_response :redirect
+    assert_equal "Signed in as test@example.com (dev mode)", flash[:notice]
+  end
+
+  test "dev signin redirects when dev user not found" do
+    User.find_by(email_address: "test@example.com")&.destroy
+
+    post dev_signin_session_url
+
+    assert_redirected_to new_session_path
+    assert_equal "Dev user not found. Run 'rails db:seed' to create it.", flash[:alert]
+  end
+end


### PR DESCRIPTION
## Summary
- Added a "Dev Sign In" button to the login page that allows one-click authentication with the seeded test user
- The button is only visible in development environment for easier testing
- Automatically signs in as test@example.com without needing to enter credentials

## Test plan
- [x] Run tests with `bin/rails t`
- [x] Run linter with `bundle exec rubocop -A`
- [x] Run security analysis with `bin/brakeman --no-pager`
- [ ] Visit http://localhost:3002/session/new and verify the green "Dev Sign In" button appears
- [ ] Click the button and verify you're signed in as test@example.com
- [ ] Verify the button does NOT appear in production environment

🤖 Generated with [Claude Code](https://claude.ai/code)