### PR TITLE
Add test sign-in helper

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "sessions#new"
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "should get new password reset form when not authenticated" do
+    get new_password_url
+    assert_response :success
+  end
+
+  test "should get edit password form with valid token" do
+    token = @user.generate_token_for(:password_reset)
+    get edit_password_url(token: token)
+    assert_response :success
+  end
+
+  test "authenticated user can access password functionality" do
+    login @user
+
+    token = @user.generate_token_for(:password_reset)
+    get edit_password_url(token: token)
+    assert_response :success
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "should get new when not authenticated" do
+    get new_session_url
+    assert_response :success
+  end
+
+  test "should create session with valid credentials" do
+    post session_url, params: { email_address: @user.email_address, password: "password" }
+    assert_response :redirect
+    assert_equal @user, current_user
+  end
+
+  test "should destroy session" do
+    login @user
+    assert_equal @user, current_user
+
+    delete session_url
+    assert_redirected_to new_session_url
+    assert_nil current_session
+  end
+
+  test "logout helper works correctly" do
+    login @user
+    assert_equal @user, current_user
+
+    logout
+    assert_nil current_session
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,5 +11,30 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+
+    def login(user)
+      user = users(user) unless user.is_a? User
+      post session_url, params: { email_address: user.email_address, password: "password" }
+      follow_redirect!
+      assert_equal user, current_user
+    end
+
+    def logout
+      delete session_url
+      assert current_session.nil?
+    end
+
+    def current_session
+      return unless cookie_jar[:session_id].present?
+      Session.find_by(id: cookie_jar.signed[:session_id])
+    end
+
+    def current_user
+      current_session&.user
+    end
+
+    def cookie_jar
+      ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add login/logout test helpers inspired by summonCircle pattern
- Create controller tests demonstrating helper usage
- Enable easier authentication testing across the test suite

## Test plan
- [x] Run tests with `bin/rails t` - all pass
- [x] Run linter with `bundle exec rubocop -A` - no offenses
- [x] Run security analysis with `bin/brakeman --no-pager` - no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)