### PR TITLE
Install letter_opener_web for development email preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Preview emails in the browser instead of sending them
+  gem "letter_opener_web", "~> 3.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -172,6 +174,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -371,6 +384,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener_web (~> 3.0)
   propshaft
   puma (>= 5.0)
   rails!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,9 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  # Use letter_opener_web to preview emails in the browser
+  config.action_mailer.delivery_method = :letter_opener_web
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   resource :registration, only: %i[new create]
   resources :passwords, param: :token
   resources :games, only: [ :new, :create ]
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Summary
- Install and configure letter_opener_web gem for development environment
- Mount engine at `/letter_opener` route accessible only in development
- Configure ActionMailer to use letter_opener_web delivery method
- Emails sent in development now viewable at http://localhost:3000/letter_opener

🤖 Generated with [Claude Code](https://claude.ai/code)