### PR TITLE
Add branch indicator to development UI

### DIFF
--- a/app/assets/stylesheets/branch-indicator.css
+++ b/app/assets/stylesheets/branch-indicator.css
@@ -1,0 +1,25 @@
+.branch-indicator {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: #2d3748;
+  color: #e2e8f0;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 14px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  opacity: 0.9;
+  transition: opacity 0.2s ease;
+}
+
+.branch-indicator:hover {
+  opacity: 1;
+}
+
+.branch-indicator::before {
+  content: "⎇ ";
+  font-size: 16px;
+  vertical-align: middle;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,14 @@ module ApplicationHelper
       }
     )
   end
+
+  def current_git_branch
+    return nil unless Rails.env.development?
+
+    begin
+      `git rev-parse --abbrev-ref HEAD`.strip
+    rescue
+      nil
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,5 +27,11 @@
       <%= render "application/flash_messages" %>
     </div>
     <%= yield %>
+
+    <% if Rails.env.development? %>
+      <div class="branch-indicator">
+        <%= current_git_branch || "unknown" %>
+      </div>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Added a visual indicator showing the current git branch in development mode
- Displays in the bottom right corner of the screen for easy reference
- Helps developers track which branch they're working on

## Implementation Details
- Added `current_git_branch` helper method to ApplicationHelper that executes git command
- Created branch-indicator.css with fixed positioning and styling
- Modified application layout to include the indicator element (only in development)
- Shows git branch icon (⎇) with the branch name
- Semi-transparent overlay that becomes fully opaque on hover

🤖 Generated with [Claude Code](https://claude.ai/code)