### PR TITLE
Use enum for game status

### DIFF
--- a/app/controllers/games/players_controller.rb
+++ b/app/controllers/games/players_controller.rb
@@ -20,6 +20,11 @@ module Games
     def destroy
       @player = Player.find(params[:id])
 
+      if @player.game.started?
+        head :unprocessable_entity
+        return
+      end
+
       if @player.user == Current.user
         @player.destroy
         redirect_to games_path, notice: success_message(@player)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -24,8 +24,20 @@ class GamesController < ApplicationController
     @game = Game.find(params[:id])
   end
 
+  def update
+    @game = Current.user.owned_games.find(params[:id])
+
+    if game_update_params[:status] == "started" && @game.players.count == 4 && @game.pending?
+      @game.started!
+      redirect_to @game, notice: success_message(@game)
+    else
+      head :unprocessable_entity
+    end
+  end
+
   def destroy
     @game = Current.user.owned_games.find(params[:id])
+    return head :unprocessable_entity unless @game.pending?
     @game.destroy
     redirect_to games_path, notice: success_message(@game)
   end
@@ -34,5 +46,9 @@ class GamesController < ApplicationController
 
   def game_params
     params.require(:game).permit(:name, :password, :password_confirmation)
+  end
+
+  def game_update_params
+    params.require(:game).permit(:status)
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -5,6 +5,8 @@ class Game < ApplicationRecord
   has_many :players, dependent: :destroy
   has_many :users, through: :players
 
+  enum :status, { pending: 0, started: 1, done: 2 }
+
   validates :name, presence: true
   validates :game_code, presence: true, uniqueness: true
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -8,6 +8,7 @@ class Player < ApplicationRecord
   validates :game, presence: { message: "invalid game code" }
   validate :game_not_full, on: :create
   validate :correct_password, on: :create, unless: :owner?
+  validate :game_not_started, on: :create
 
   scope :owner, -> { where(owner: true) }
 
@@ -24,5 +25,11 @@ class Player < ApplicationRecord
     return if game.authenticate_for_join(password)
 
     errors.add(:password, :invalid)
+  end
+
+  def game_not_started
+    return unless game
+
+    errors.add(:game, :started) if game.started?
   end
 end

--- a/app/views/games/_lobby.html.erb
+++ b/app/views/games/_lobby.html.erb
@@ -1,0 +1,39 @@
+<div class="container">
+  <h1><%= @game.name %></h1>
+
+  <div class="game-info">
+    <p><strong>Game Code:</strong> <%= @game.game_code %></p>
+    <% if @game.password_digest.present? %>
+      <p><em>This game is password protected</em></p>
+    <% end %>
+  </div>
+
+  <div class="players">
+    <h2>Players (<%= @game.players.count %>/4)</h2>
+    <ul>
+      <% @game.players.includes(:user).each do |player| %>
+        <li>
+          <%= player.user.name %>
+          <% if player.owner? %>
+            <span class="badge">Owner</span>
+          <% end %>
+          <% if @game.owner == Current.user && player.user != Current.user %>
+            <%= button_to "Kick", games_player_path(player), method: :delete, class: "button --small" %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="actions">
+    <% if @game.owner == Current.user && @game.players.count == 4 %>
+      <%= button_to "Start Game", game_path(@game), method: :patch, params: { game: { status: :started } }, class: "button" %>
+    <% end %>
+    <% if @game.owner == Current.user %>
+      <%= button_to "Delete Game", game_path(@game), method: :delete, class: "button" %>
+    <% elsif (player = @game.players.find_by(user: Current.user)) %>
+      <%= button_to "Quit Game", games_player_path(player), method: :delete, class: "button" %>
+    <% end %>
+    <%= link_to "Back to Dashboard", root_path, class: "button" %>
+  </div>
+</div>

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -1,0 +1,3 @@
+<div class="container">
+  <h1><%= @game.name %> - Play Area</h1>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,36 +1,5 @@
-<div class="container">
-  <h1><%= @game.name %></h1>
-
-  <div class="game-info">
-    <p><strong>Game Code:</strong> <%= @game.game_code %></p>
-    <% if @game.password_digest.present? %>
-      <p><em>This game is password protected</em></p>
-    <% end %>
-  </div>
-
-  <div class="players">
-    <h2>Players (<%= @game.players.count %>/4)</h2>
-    <ul>
-      <% @game.players.includes(:user).each do |player| %>
-        <li>
-          <%= player.user.name %>
-          <% if player.owner? %>
-            <span class="badge">Owner</span>
-          <% end %>
-          <% if @game.owner == Current.user && player.user != Current.user %>
-            <%= button_to "Kick", games_player_path(player), method: :delete, class: "button --small" %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-
-  <div class="actions">
-    <% if @game.owner == Current.user %>
-      <%= button_to "Delete Game", game_path(@game), method: :delete, class: "button" %>
-    <% elsif (player = @game.players.find_by(user: Current.user)) %>
-      <%= button_to "Quit Game", games_player_path(player), method: :delete, class: "button" %>
-    <% end %>
-    <%= link_to "Back to Dashboard", root_path, class: "button" %>
-  </div>
-</div>
+<% if @game.started? %>
+  <%= render 'play' %>
+<% else %>
+  <%= render 'lobby' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
           attributes:
             game:
               full: "is full"
+              started: "has already started"
   application:
     form_errors:
       title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resource :session
   resource :registration, only: %i[new create]
   resources :passwords, param: :token
-  resources :games, only: [ :index, :new, :create, :show, :destroy ]
+  resources :games, only: [ :index, :new, :create, :show, :update, :destroy ]
 
   namespace :games do
     resources :players

--- a/db/migrate/20250614081354_add_status_to_games.rb
+++ b/db/migrate/20250614081354_add_status_to_games.rb
@@ -1,0 +1,5 @@
+class AddStatusToGames < ActiveRecord::Migration[8.1]
+  def change
+    add_column :games, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_06_12_010810) do
+ActiveRecord::Schema[8.1].define(version: 2025_06_14_081354) do
   create_table "friendships", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "friend_id", null: false
     t.boolean "pending", default: true, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index [ "friend_id" ], name: "index_friendships_on_friend_id"
-    t.index [ "pending" ], name: "index_friendships_on_pending"
-    t.index [ "user_id", "friend_id" ], name: "index_friendships_on_user_id_and_friend_id", unique: true
-    t.index [ "user_id" ], name: "index_friendships_on_user_id"
+    t.index ["friend_id"], name: "index_friendships_on_friend_id"
+    t.index ["pending"], name: "index_friendships_on_pending"
+    t.index ["user_id", "friend_id"], name: "index_friendships_on_user_id_and_friend_id", unique: true
+    t.index ["user_id"], name: "index_friendships_on_user_id"
   end
 
   create_table "games", force: :cascade do |t|
@@ -28,8 +28,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_06_12_010810) do
     t.string "game_code"
     t.string "name"
     t.string "password_digest"
+    t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.index [ "game_code" ], name: "index_games_on_game_code", unique: true
+    t.index ["game_code"], name: "index_games_on_game_code", unique: true
   end
 
   create_table "players", force: :cascade do |t|
@@ -38,9 +39,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_06_12_010810) do
     t.boolean "owner", default: false, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index [ "game_id", "user_id" ], name: "index_players_on_game_id_and_user_id", unique: true
-    t.index [ "game_id" ], name: "index_players_on_game_id"
-    t.index [ "user_id" ], name: "index_players_on_user_id"
+    t.index ["game_id", "user_id"], name: "index_players_on_game_id_and_user_id", unique: true
+    t.index ["game_id"], name: "index_players_on_game_id"
+    t.index ["user_id"], name: "index_players_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -49,7 +50,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_06_12_010810) do
     t.datetime "updated_at", null: false
     t.string "user_agent"
     t.integer "user_id", null: false
-    t.index [ "user_id" ], name: "index_sessions_on_user_id"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -59,8 +60,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_06_12_010810) do
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
     t.string "user_code"
-    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
-    t.index [ "user_code" ], name: "index_users_on_user_code", unique: true
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["user_code"], name: "index_users_on_user_code", unique: true
   end
 
   add_foreign_key "friendships", "users"

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -78,4 +78,33 @@ class GamesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
   end
+
+  test "owner can start full game" do
+    game = games(:full_game)
+    sign_in_as(game.owner)
+
+    patch game_url(game), params: { game: { status: "started" } }
+
+    assert_redirected_to game_url(game)
+    assert game.reload.started?
+  end
+
+  test "cannot start non full game" do
+    game = games(:one)
+
+    patch game_url(game), params: { game: { status: "started" } }
+
+    assert_response :unprocessable_entity
+    assert_not game.reload.started?
+  end
+
+  test "cannot delete started game" do
+    game = games(:started_game)
+    sign_in_as(game.owner)
+
+    delete game_url(game)
+
+    assert_response :unprocessable_entity
+    assert Game.exists?(game.id)
+  end
 end

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -9,3 +9,8 @@ two:
 full_game:
   name: Full Game
   game_code: FULL01
+
+started_game:
+  name: Started Game
+  status: started
+  game_code: START1

--- a/test/fixtures/players.yml
+++ b/test/fixtures/players.yml
@@ -34,3 +34,13 @@ full_game_player_four:
   user: stranger_one
   game: full_game
   owner: false
+
+started_game_owner:
+  user: one
+  game: started_game
+  owner: true
+
+started_game_player_two:
+  user: two
+  game: started_game
+  owner: false


### PR DESCRIPTION
## Summary
- allow PATCH update to start a game
- lock game actions after starting
- render lobby or play partials from show
- track game `status` via enum
- update tests for new start flow

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d2e7df354832daa948ad6c32572b3