### PR TITLE
Hide delete button for started games

### DIFF
--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -19,10 +19,12 @@
             <% end %>
           </p>
           <p>
-            <% if game.owner == Current.user %>
-              <%= button_to "Delete", game_path(game), method: :delete, class: "button --small" %>
-            <% elsif (player = game.players.find_by(user: Current.user)) %>
-              <%= button_to "Quit", games_player_path(player), method: :delete, class: "button --small" %>
+            <% unless game.started? %>
+              <% if game.owner == Current.user %>
+                <%= button_to "Delete", game_path(game), method: :delete, class: "button --small" %>
+              <% elsif (player = game.players.find_by(user: Current.user)) %>
+                <%= button_to "Quit", games_player_path(player), method: :delete, class: "button --small" %>
+              <% end %>
             <% end %>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- hide delete and quit actions when a game has started

## Testing
- `bundle exec rubocop -A`
- `bin/rails t`
- `bin/brakeman --no-pager` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e393e0508832d9a191cfb73a546c1